### PR TITLE
fix(r2v): type error of context_parallel_for_reference.py

### DIFF
--- a/skyreels_v3/distributed/context_parallel_for_reference.py
+++ b/skyreels_v3/distributed/context_parallel_for_reference.py
@@ -138,6 +138,7 @@ def parallelize_transformer(pipe: DiffusionPipeline):
         encoder_hidden_states_image: Optional[torch.Tensor] = None,
         return_dict: bool = True,
         attention_kwargs: Optional[Dict[str, Any]] = None,
+        block_offload: bool = False,
     ) -> Union[torch.Tensor, Dict[str, torch.Tensor]]:
         if attention_kwargs is not None:
             lora_scale = attention_kwargs.pop("scale", 1.0)


### PR DESCRIPTION
## command
```bash
torchrun --nproc_per_node=4 generate_video.py --task_type reference_to_video --ref_imgs "https://skyreels-api.oss-accelerate.aliyuncs.com/examples/subject_reference/0_1.png,https://skyreels-api.oss-accelerate.aliyuncs.com/examples/subject_reference/0_2.png" --prompt "In a dimly lit, cluttered occult club room adorned with shelves full of books, skulls, and mysterious dolls, two young Asian girls are talking. One girl has vibrant teal pigtails with bangs, wearing a white collared polo shirt, while the other has a sleek black bob with bangs, also in a white polo shirt, conversing under the hum of fluorescent lights, a high-quality and detailed cinematic shot." --duration 5 --use_usp
```

## error
```
[rank0]: Traceback (most recent call last):
[rank0]:   File "/SkyReels-V3/generate_video.py", line 289, in <module>
[rank0]:     video_out = pipe.generate_video(args.ref_imgs, args.prompt, args.duration, args.seed, resolution=args.resolution)
[rank0]:   File "/SkyReels-V3/skyreels_v3/pipelines/reference_to_video_pipeline.py", line 791, in generate_video
[rank0]:     video_pt = self.pipeline(**kwargs).frames
[rank0]:   File "/lib/python3.10/site-packages/torch/utils/_contextlib.py", line 120, in decorate_context
[rank0]:     return func(*args, **kwargs)
[rank0]:   File "/SkyReels-V3/skyreels_v3/pipelines/reference_to_video_pipeline.py", line 549, in __call__
[rank0]:     noise_pred = self.transformer(
[rank0]:   File "/lib/python3.10/site-packages/torch/nn/modules/module.py", line 1773, in _wrapped_call_impl
[rank0]:     return self._call_impl(*args, **kwargs)
[rank0]:   File "/lib/python3.10/site-packages/torch/nn/modules/module.py", line 1784, in _call_impl
[rank0]:     return forward_call(*args, **kwargs)
[rank0]: TypeError: SkyReelsA2WanI2v3DModel.forward() got an unexpected keyword argument 'block_offload'
```

## how to fix
![image](https://github.com/user-attachments/assets/230bade4-160b-47a8-9619-371fc5a6beeb)
